### PR TITLE
Auto-fill wizard name field from OAuth display name

### DIFF
--- a/src/Pia.Wpf/ViewModels/FirstRunWizardViewModel.cs
+++ b/src/Pia.Wpf/ViewModels/FirstRunWizardViewModel.cs
@@ -341,6 +341,9 @@ public partial class FirstRunWizardViewModel : ObservableObject
                 LoginDisplayName = _authService.UserDisplayName;
                 LoginEmail = _authService.UserEmail;
 
+                if (string.IsNullOrWhiteSpace(UserName) && !string.IsNullOrWhiteSpace(_authService.UserDisplayName))
+                    UserName = _authService.UserDisplayName;
+
                 await _providerService.EnsureBuiltInProviderAsync();
                 await HandlePostLoginSyncAsync();
 


### PR DESCRIPTION
After a successful Microsoft/Google login in the first-run wizard,
populate the profile step's UserName with UserDisplayName so the user
doesn't have to retype it. Skips if the user already entered a name.