### PR TITLE
Unify sidebar: primary features always visible, mode items nest

### DIFF
--- a/src/Pia.Wpf/Models/ManagedWindow.cs
+++ b/src/Pia.Wpf/Models/ManagedWindow.cs
@@ -5,7 +5,7 @@ namespace Pia.Models;
 public class ManagedWindow : IDisposable
 {
     public Guid Id { get; }
-    public WindowMode Mode { get; }
+    public WindowMode Mode { get; internal set; }
     public MainWindow Window { get; }
     public IServiceScope Scope { get; }
 

--- a/src/Pia.Wpf/Services/Interfaces/IWindowManagerService.cs
+++ b/src/Pia.Wpf/Services/Interfaces/IWindowManagerService.cs
@@ -10,7 +10,7 @@ public interface IWindowManagerService
     event EventHandler<ManagedWindow>? WindowClosed;
     event EventHandler? WindowVisibilityChanged;
 
-    void ShowWindow(WindowMode mode);
+    void ShowWindow(WindowMode mode, bool navigateToMain = false);
     void ShowWindowWithText(WindowMode mode, string text);
     void ShowFirstRunWizard();
     void HideWindow(WindowMode mode);
@@ -19,4 +19,5 @@ public interface IWindowManagerService
     bool IsVisible(WindowMode mode);
     bool IsInForeground(WindowMode mode);
     bool CanDismissWithHotkey(WindowMode mode);
+    bool TryChangeWindowMode(WindowMode oldMode, WindowMode newMode);
 }

--- a/src/Pia.Wpf/Services/TrayIconService.cs
+++ b/src/Pia.Wpf/Services/TrayIconService.cs
@@ -182,7 +182,7 @@ public class TrayIconService : NotifyIconService, ITrayIconService, IDisposable
             else
             {
                 _windowTrackingService.TrackWindowAtCursor();
-                _windowManagerService.ShowWindow(mode);
+                _windowManagerService.ShowWindow(mode, navigateToMain: true);
             }
             return;
         }
@@ -193,7 +193,7 @@ public class TrayIconService : NotifyIconService, ITrayIconService, IDisposable
         _lastHotkeyOpenTime = now;
 
         _windowTrackingService.TrackWindowAtCursor();
-        _windowManagerService.ShowWindow(mode);
+        _windowManagerService.ShowWindow(mode, navigateToMain: true);
     }
 
     private void UpdateTooltip()

--- a/src/Pia.Wpf/Services/WindowManagerService.cs
+++ b/src/Pia.Wpf/Services/WindowManagerService.cs
@@ -32,7 +32,7 @@ public partial class WindowManagerService : IWindowManagerService
         _rootProvider = rootProvider;
     }
 
-    public void ShowWindow(WindowMode mode)
+    public void ShowWindow(WindowMode mode, bool navigateToMain = false)
     {
         if (_windows.TryGetValue(mode, out var existing))
         {
@@ -43,6 +43,10 @@ public partial class WindowManagerService : IWindowManagerService
             existing.Window.Activate();
             existing.Window.Focus();
             existing.Window.Topmost = false;
+
+            if (navigateToMain)
+                NavigateToMainView(existing, mode);
+
             WindowVisibilityChanged?.Invoke(this, EventArgs.Empty);
             return;
         }
@@ -124,6 +128,48 @@ public partial class WindowManagerService : IWindowManagerService
                 break;
             case WindowMode.Research:
                 navigationService.NavigateTo<ResearchViewModel, string>(text);
+                break;
+        }
+    }
+
+    public bool TryChangeWindowMode(WindowMode oldMode, WindowMode newMode)
+    {
+        if (oldMode == newMode)
+            return true;
+
+        if (!_windows.TryGetValue(oldMode, out var managed))
+            return false;
+
+        if (_windows.TryGetValue(newMode, out var other) && !ReferenceEquals(other, managed))
+        {
+            ShowWindow(newMode);
+            return false;
+        }
+
+        _windows.Remove(oldMode);
+        managed.Mode = newMode;
+        _windows[newMode] = managed;
+
+        if (managed.Window.DataContext is MainWindowViewModel vm)
+            vm.Mode = newMode;
+
+        WindowVisibilityChanged?.Invoke(this, EventArgs.Empty);
+        return true;
+    }
+
+    private static void NavigateToMainView(ManagedWindow managed, WindowMode mode)
+    {
+        var navigationService = managed.Scope.ServiceProvider.GetRequiredService<INavigationService>();
+        switch (mode)
+        {
+            case WindowMode.Optimize:
+                navigationService.NavigateTo<OptimizeViewModel>();
+                break;
+            case WindowMode.Assistant:
+                navigationService.NavigateTo<AssistantViewModel>();
+                break;
+            case WindowMode.Research:
+                navigationService.NavigateTo<ResearchViewModel>();
                 break;
         }
     }

--- a/src/Pia.Wpf/ViewModels/MainWindowViewModel.cs
+++ b/src/Pia.Wpf/ViewModels/MainWindowViewModel.cs
@@ -253,53 +253,31 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
 
     private void ExecuteNavigationCommand(string? destination)
     {
-        // Map keyboard shortcut indices to mode-specific destinations
         var resolved = destination switch
         {
-            "Shortcut1" => Mode switch
-            {
-                WindowMode.Optimize => "Optimize",
-                WindowMode.Assistant => "Assistant",
-                WindowMode.Research => "Research",
-                _ => null
-            },
-            "Shortcut2" => Mode switch
-            {
-                WindowMode.Optimize => "History",
-                WindowMode.Assistant => "Memory",
-                WindowMode.Research => "Settings",
-                _ => null
-            },
-            "Shortcut3" => Mode switch
-            {
-                WindowMode.Optimize => "Settings",
-                WindowMode.Assistant => "Reminders",
-                _ => null
-            },
-            "Shortcut4" => Mode switch
-            {
-                WindowMode.Assistant => "Settings",
-                _ => null
-            },
+            "Shortcut1" => "Optimize",
+            "Shortcut2" => "Assistant",
+            "Shortcut3" => "Research",
+            "Shortcut4" => "Settings",
             _ => destination
         };
 
         switch (resolved)
         {
             case "Optimize":
-                _navigationService.NavigateTo<OptimizeViewModel>();
+                NavigateToPrimary(WindowMode.Optimize);
+                break;
+            case "Assistant":
+                NavigateToPrimary(WindowMode.Assistant);
+                break;
+            case "Research":
+                NavigateToPrimary(WindowMode.Research);
                 break;
             case "History":
                 _navigationService.NavigateTo<HistoryViewModel>();
                 break;
             case "Settings":
                 _navigationService.NavigateTo<SettingsViewModel>();
-                break;
-            case "Assistant":
-                _navigationService.NavigateTo<AssistantViewModel>();
-                break;
-            case "Research":
-                _navigationService.NavigateTo<ResearchViewModel>();
                 break;
             case "Memory":
                 _navigationService.NavigateTo<MemoryViewModel>();
@@ -309,6 +287,25 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
                 break;
             case "Todo":
                 _navigationService.NavigateTo<TodoViewModel>();
+                break;
+        }
+    }
+
+    private void NavigateToPrimary(WindowMode target)
+    {
+        if (target != Mode && !_windowManagerService.TryChangeWindowMode(Mode, target))
+            return;
+
+        switch (target)
+        {
+            case WindowMode.Optimize:
+                _navigationService.NavigateTo<OptimizeViewModel>();
+                break;
+            case WindowMode.Assistant:
+                _navigationService.NavigateTo<AssistantViewModel>();
+                break;
+            case WindowMode.Research:
+                _navigationService.NavigateTo<ResearchViewModel>();
                 break;
         }
     }

--- a/src/Pia.Wpf/Views/NavigationSidebarView.xaml
+++ b/src/Pia.Wpf/Views/NavigationSidebarView.xaml
@@ -14,11 +14,10 @@
                      Transition="FadeInWithSlide">
 
     <ui:NavigationView.MenuItems>
-      <!-- Optimize mode items -->
+      <!-- Optimize (always visible, sub-menu renders only in Optimize mode) -->
       <ui:NavigationViewItem Command="{Binding NavigationCommand}"
                              CommandParameter="Optimize"
-                             IsActive="{Binding CurrentNavigationItem, Converter={StaticResource StringEqualsBoolConverter}, ConverterParameter=Optimize}"
-                             Visibility="{Binding Mode, Converter={StaticResource WindowModeToVisibilityConverter}, ConverterParameter=Optimize}">
+                             IsActive="{Binding CurrentNavigationItem, Converter={StaticResource StringEqualsBoolConverter}, ConverterParameter=Optimize}">
         <ui:NavigationViewItem.Content>
           <StackPanel Orientation="Horizontal">
             <TextBlock Text="{loc:Str Nav_Optimize}" />
@@ -29,13 +28,23 @@
         <ui:NavigationViewItem.Icon>
           <ui:SymbolIcon Symbol="Sparkle24" />
         </ui:NavigationViewItem.Icon>
+        <ui:NavigationViewItem.MenuItems>
+          <ui:NavigationViewItem Content="{loc:Str Nav_History}"
+                                 Command="{Binding NavigationCommand}"
+                                 CommandParameter="History"
+                                 IsActive="{Binding CurrentNavigationItem, Converter={StaticResource StringEqualsBoolConverter}, ConverterParameter=History}"
+                                 Visibility="{Binding Mode, Converter={StaticResource WindowModeToVisibilityConverter}, ConverterParameter=Optimize}">
+            <ui:NavigationViewItem.Icon>
+              <ui:SymbolIcon Symbol="Clock24" />
+            </ui:NavigationViewItem.Icon>
+          </ui:NavigationViewItem>
+        </ui:NavigationViewItem.MenuItems>
       </ui:NavigationViewItem>
 
-      <!-- Assistant mode items -->
+      <!-- Assistant (always visible, sub-menu renders only in Assistant mode) -->
       <ui:NavigationViewItem Command="{Binding NavigationCommand}"
                              CommandParameter="Assistant"
-                             IsActive="{Binding CurrentNavigationItem, Converter={StaticResource StringEqualsBoolConverter}, ConverterParameter=Assistant}"
-                             Visibility="{Binding Mode, Converter={StaticResource WindowModeToVisibilityConverter}, ConverterParameter=Assistant}">
+                             IsActive="{Binding CurrentNavigationItem, Converter={StaticResource StringEqualsBoolConverter}, ConverterParameter=Assistant}">
         <ui:NavigationViewItem.Content>
           <StackPanel Orientation="Horizontal">
             <TextBlock Text="{loc:Str Nav_Assistant}" />
@@ -46,13 +55,32 @@
         <ui:NavigationViewItem.Icon>
           <ui:SymbolIcon Symbol="Chat24" />
         </ui:NavigationViewItem.Icon>
+        <ui:NavigationViewItem.MenuItems>
+          <ui:NavigationViewItem Content="{loc:Str Nav_Memory}"
+                                 Command="{Binding NavigationCommand}"
+                                 CommandParameter="Memory"
+                                 IsActive="{Binding CurrentNavigationItem, Converter={StaticResource StringEqualsBoolConverter}, ConverterParameter=Memory}"
+                                 Visibility="{Binding Mode, Converter={StaticResource WindowModeToVisibilityConverter}, ConverterParameter=Assistant}">
+            <ui:NavigationViewItem.Icon>
+              <ui:SymbolIcon Symbol="BrainCircuit24" />
+            </ui:NavigationViewItem.Icon>
+          </ui:NavigationViewItem>
+          <ui:NavigationViewItem Content="{loc:Str Nav_Reminders}"
+                                 Command="{Binding NavigationCommand}"
+                                 CommandParameter="Reminders"
+                                 IsActive="{Binding CurrentNavigationItem, Converter={StaticResource StringEqualsBoolConverter}, ConverterParameter=Reminders}"
+                                 Visibility="{Binding Mode, Converter={StaticResource WindowModeToVisibilityConverter}, ConverterParameter=Assistant}">
+            <ui:NavigationViewItem.Icon>
+              <ui:SymbolIcon Symbol="Alert24" />
+            </ui:NavigationViewItem.Icon>
+          </ui:NavigationViewItem>
+        </ui:NavigationViewItem.MenuItems>
       </ui:NavigationViewItem>
 
-      <!-- Research mode items -->
+      <!-- Research (always visible, no sub-items today) -->
       <ui:NavigationViewItem Command="{Binding NavigationCommand}"
                              CommandParameter="Research"
-                             IsActive="{Binding CurrentNavigationItem, Converter={StaticResource StringEqualsBoolConverter}, ConverterParameter=Research}"
-                             Visibility="{Binding Mode, Converter={StaticResource WindowModeToVisibilityConverter}, ConverterParameter=Research}">
+                             IsActive="{Binding CurrentNavigationItem, Converter={StaticResource StringEqualsBoolConverter}, ConverterParameter=Research}">
         <ui:NavigationViewItem.Content>
           <StackPanel Orientation="Horizontal">
             <TextBlock Text="{loc:Str Nav_Research}" />
@@ -65,43 +93,11 @@
         </ui:NavigationViewItem.Icon>
       </ui:NavigationViewItem>
 
-      <!-- History (Optimize only) -->
-      <ui:NavigationViewItem Content="{loc:Str Nav_History}"
-                             Command="{Binding NavigationCommand}"
-                             CommandParameter="History"
-                             IsActive="{Binding CurrentNavigationItem, Converter={StaticResource StringEqualsBoolConverter}, ConverterParameter=History}"
-                             Visibility="{Binding Mode, Converter={StaticResource WindowModeToVisibilityConverter}, ConverterParameter=Optimize}">
-        <ui:NavigationViewItem.Icon>
-          <ui:SymbolIcon Symbol="Clock24" />
-        </ui:NavigationViewItem.Icon>
-      </ui:NavigationViewItem>
-
-      <!-- Memory (Assistant only) -->
-      <ui:NavigationViewItem Content="{loc:Str Nav_Memory}"
-                             Command="{Binding NavigationCommand}"
-                             CommandParameter="Memory"
-                             IsActive="{Binding CurrentNavigationItem, Converter={StaticResource StringEqualsBoolConverter}, ConverterParameter=Memory}"
-                             Visibility="{Binding Mode, Converter={StaticResource WindowModeToVisibilityConverter}, ConverterParameter=Assistant}">
-        <ui:NavigationViewItem.Icon>
-          <ui:SymbolIcon Symbol="BrainCircuit24" />
-        </ui:NavigationViewItem.Icon>
-      </ui:NavigationViewItem>
-
-      <!-- Reminders (Assistant only) -->
-      <ui:NavigationViewItem Content="{loc:Str Nav_Reminders}"
-                             Command="{Binding NavigationCommand}"
-                             CommandParameter="Reminders"
-                             IsActive="{Binding CurrentNavigationItem, Converter={StaticResource StringEqualsBoolConverter}, ConverterParameter=Reminders}"
-                             Visibility="{Binding Mode, Converter={StaticResource WindowModeToVisibilityConverter}, ConverterParameter=Assistant}">
-        <ui:NavigationViewItem.Icon>
-          <ui:SymbolIcon Symbol="Alert24" />
-        </ui:NavigationViewItem.Icon>
-      </ui:NavigationViewItem>
-
       <!-- Todo (all modes) -->
       <ui:NavigationViewItem Content="{loc:Str Nav_Todo}"
                              Command="{Binding NavigationCommand}"
-                             CommandParameter="Todo">
+                             CommandParameter="Todo"
+                             IsActive="{Binding CurrentNavigationItem, Converter={StaticResource StringEqualsBoolConverter}, ConverterParameter=Todo}">
         <ui:NavigationViewItem.Icon>
           <ui:SymbolIcon Symbol="TaskListSquareLtr24" />
         </ui:NavigationViewItem.Icon>


### PR DESCRIPTION
Optimize, Assistant, Research, Todo and Settings now sit at the main
layer in every window Mode. History, Memory and Reminders become
sub-menu children of their matching parent (visible only in that
parent's Mode). Ctrl+1..4 map fixed to Optimize/Assistant/Research/
Settings regardless of Mode.

Clicking a primary feature in the sidebar now hands the window off
to that Mode via WindowManagerService.TryChangeWindowMode, which
re-keys the per-mode window dictionary, updates ManagedWindow.Mode
and MainWindowViewModel.Mode (cascading the title and tray state),
or focuses an existing window of the target Mode without disturbing
this one. Global hotkey presses that hit an already-open window of
the target Mode now also renavigate that window to its main view.