### PR TITLE
Enhance ResearchView: markdown rendering, file export, and history

### DIFF
--- a/src/Pia.Wpf/App.xaml
+++ b/src/Pia.Wpf/App.xaml
@@ -55,6 +55,9 @@
       <DataTemplate DataType="{x:Type viewModels:ResearchViewModel}">
         <views:ResearchView />
       </DataTemplate>
+      <DataTemplate DataType="{x:Type viewModels:ResearchHistoryViewModel}">
+        <views:ResearchHistoryView />
+      </DataTemplate>
       <DataTemplate DataType="{x:Type viewModels:MemoryViewModel}">
         <views:MemoryView />
       </DataTemplate>

--- a/src/Pia.Wpf/Bootstrapper.cs
+++ b/src/Pia.Wpf/Bootstrapper.cs
@@ -149,6 +149,8 @@ public static class Bootstrapper
         services.AddSingleton<ISettingsService, SettingsService>();
         services.AddSingleton<ITemplateService, TemplateService>();
         services.AddSingleton<IHistoryService, HistoryService>();
+        services.AddSingleton<IResearchHistoryService, ResearchHistoryService>();
+        services.AddTransient<IResearchExportService, ResearchExportService>();
         services.AddSingleton<IWindowTrackingService, WindowTrackingService>();
         services.AddSingleton<INativeHotkeyServiceFactory, NativeHotkeyServiceFactory>();
         services.AddSingleton<ITrayIconService, TrayIconService>();
@@ -200,6 +202,7 @@ public static class Bootstrapper
         services.AddScoped<HistoryViewModel>();
         services.AddScoped<AssistantViewModel>();
         services.AddScoped<ResearchViewModel>();
+        services.AddScoped<ResearchHistoryViewModel>();
         services.AddScoped<MemoryViewModel>();
         services.AddScoped<RemindersViewModel>();
         services.AddScoped<TodoViewModel>();

--- a/src/Pia.Wpf/Infrastructure/SqliteContext.cs
+++ b/src/Pia.Wpf/Infrastructure/SqliteContext.cs
@@ -105,6 +105,21 @@ public class SqliteContext : IDisposable
             CREATE INDEX IF NOT EXISTS IX_Todos_Status ON Todos(Status);
             CREATE INDEX IF NOT EXISTS IX_Todos_Priority ON Todos(Priority);
             CREATE INDEX IF NOT EXISTS IX_Todos_DueDate ON Todos(DueDate);
+
+            CREATE TABLE IF NOT EXISTS ResearchSessions (
+                Id TEXT PRIMARY KEY,
+                Query TEXT NOT NULL,
+                SynthesizedResult TEXT NOT NULL DEFAULT '',
+                StepsJson TEXT NOT NULL DEFAULT '[]',
+                ProviderId TEXT NOT NULL,
+                ProviderName TEXT,
+                Status TEXT NOT NULL DEFAULT 'Completed',
+                StepCount INTEGER NOT NULL DEFAULT 0,
+                CreatedAt TEXT NOT NULL,
+                CompletedAt TEXT NOT NULL
+            );
+
+            CREATE INDEX IF NOT EXISTS IX_ResearchSessions_CreatedAt ON ResearchSessions(CreatedAt);
             """;
         command.ExecuteNonQuery();
 

--- a/src/Pia.Wpf/Models/ResearchHistoryEntry.cs
+++ b/src/Pia.Wpf/Models/ResearchHistoryEntry.cs
@@ -1,0 +1,34 @@
+namespace Pia.Models;
+
+public class ResearchHistoryEntry
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string Query { get; set; } = string.Empty;
+    public string SynthesizedResult { get; set; } = string.Empty;
+    public string StepsJson { get; set; } = "[]";
+    public Guid ProviderId { get; set; }
+    public string? ProviderName { get; set; }
+    public string Status { get; set; } = "Completed";
+    public int StepCount { get; set; }
+    public DateTime CreatedAt { get; set; } = DateTime.Now;
+    public DateTime CompletedAt { get; set; } = DateTime.Now;
+
+    /// <summary>
+    /// Truncated query for display in list views.
+    /// </summary>
+    public string QueryPreview => Query.Length > 120 ? Query[..120] + "..." : Query;
+
+    /// <summary>
+    /// Truncated result for display in list views.
+    /// </summary>
+    public string ResultPreview =>
+        SynthesizedResult.Length > 200 ? SynthesizedResult[..200] + "..." : SynthesizedResult;
+}
+
+public class ResearchStepDto
+{
+    public int StepNumber { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public string Content { get; set; } = string.Empty;
+    public string Status { get; set; } = "Completed";
+}

--- a/src/Pia.Wpf/Pia.Wpf.csproj
+++ b/src/Pia.Wpf/Pia.Wpf.csproj
@@ -41,12 +41,18 @@
     <PackageReference Include="NReco.Logging.File" Version="1.3.1" />
     <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.21.0" />
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
+    <PackageReference Include="Markdig" Version="0.39.1" />
     <PackageReference Include="Velopack" Version="0.0.1442-gfaff302" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Pia.Shared\Pia.Shared.csproj" />
     <ProjectReference Include="..\..\lib\MdXaml\MdXaml\MdXaml.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="ReachFramework" />
+    <Reference Include="System.Printing" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Pia.Wpf/Resources/Strings/MessageStrings.de.resx
+++ b/src/Pia.Wpf/Resources/Strings/MessageStrings.de.resx
@@ -118,6 +118,10 @@
   <data name="Msg_Research_Exported" xml:space="preserve"><value>Exportiert</value></data>
   <data name="Msg_Research_Failed" xml:space="preserve"><value>Recherche fehlgeschlagen: {0}</value></data>
   <data name="Msg_Research_FullResearchExported" xml:space="preserve"><value>Vollständige Recherche in die Zwischenablage exportiert.</value></data>
+  <data name="Msg_Research_ExportedToFile" xml:space="preserve"><value>Recherche exportiert nach {0}</value></data>
+  <data name="Msg_ResearchHistory_ConfirmDeleteTitle" xml:space="preserve"><value>Recherche löschen</value></data>
+  <data name="Msg_ResearchHistory_ConfirmDeleteMessage" xml:space="preserve"><value>Möchten Sie diese Recherche wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.</value></data>
+  <data name="Msg_ResearchHistory_DeleteFailed" xml:space="preserve"><value>Recherche konnte nicht gelöscht werden: {0}</value></data>
   <data name="Msg_Research_NoProviderConfigured" xml:space="preserve"><value>Kein KI-Anbieter für den Recherchemodus konfiguriert. Bitte füge einen in den Einstellungen hinzu.</value></data>
   <data name="Msg_Research_ResultCopied" xml:space="preserve"><value>Rechercheergebnis in die Zwischenablage kopiert.</value></data>
   <!-- Settings messages -->

--- a/src/Pia.Wpf/Resources/Strings/MessageStrings.fr.resx
+++ b/src/Pia.Wpf/Resources/Strings/MessageStrings.fr.resx
@@ -118,6 +118,10 @@
   <data name="Msg_Research_Exported" xml:space="preserve"><value>Exporté</value></data>
   <data name="Msg_Research_Failed" xml:space="preserve"><value>La recherche a échoué : {0}</value></data>
   <data name="Msg_Research_FullResearchExported" xml:space="preserve"><value>Recherche complète exportée dans le presse-papiers.</value></data>
+  <data name="Msg_Research_ExportedToFile" xml:space="preserve"><value>Recherche exportée vers {0}</value></data>
+  <data name="Msg_ResearchHistory_ConfirmDeleteTitle" xml:space="preserve"><value>Supprimer la recherche</value></data>
+  <data name="Msg_ResearchHistory_ConfirmDeleteMessage" xml:space="preserve"><value>Êtes-vous sûr de vouloir supprimer cette session de recherche ? Cette action est irréversible.</value></data>
+  <data name="Msg_ResearchHistory_DeleteFailed" xml:space="preserve"><value>Échec de la suppression de la session de recherche : {0}</value></data>
   <data name="Msg_Research_NoProviderConfigured" xml:space="preserve"><value>Aucun fournisseur d'IA configuré pour le mode Recherche. Veuillez en ajouter un dans les Paramètres.</value></data>
   <data name="Msg_Research_ResultCopied" xml:space="preserve"><value>Résultat de recherche copié dans le presse-papiers.</value></data>
   <!-- Settings messages -->

--- a/src/Pia.Wpf/Resources/Strings/MessageStrings.resx
+++ b/src/Pia.Wpf/Resources/Strings/MessageStrings.resx
@@ -123,6 +123,10 @@
   <data name="Msg_Research_Exported" xml:space="preserve"><value>Exported</value></data>
   <data name="Msg_Research_Failed" xml:space="preserve"><value>Research failed: {0}</value></data>
   <data name="Msg_Research_FullResearchExported" xml:space="preserve"><value>Full research exported to clipboard.</value></data>
+  <data name="Msg_Research_ExportedToFile" xml:space="preserve"><value>Research exported to {0}</value></data>
+  <data name="Msg_ResearchHistory_ConfirmDeleteTitle" xml:space="preserve"><value>Delete Research</value></data>
+  <data name="Msg_ResearchHistory_ConfirmDeleteMessage" xml:space="preserve"><value>Are you sure you want to delete this research session? This action cannot be undone.</value></data>
+  <data name="Msg_ResearchHistory_DeleteFailed" xml:space="preserve"><value>Failed to delete research session: {0}</value></data>
   <data name="Msg_Research_NoProviderConfigured" xml:space="preserve"><value>No AI provider configured for Research mode. Please add one in Settings.</value></data>
   <data name="Msg_Research_ResultCopied" xml:space="preserve"><value>Research result copied to clipboard.</value></data>
 

--- a/src/Pia.Wpf/Resources/Strings/ViewStrings.de.resx
+++ b/src/Pia.Wpf/Resources/Strings/ViewStrings.de.resx
@@ -103,6 +103,26 @@
   <data name="Research_ExportAll" xml:space="preserve"><value>Alles exportieren</value></data>
   <data name="Research_NewResearch" xml:space="preserve"><value>Neue Recherche</value></data>
   <data name="Research_ToggleTodoPanel_Tooltip" xml:space="preserve"><value>Aufgabenleiste ein-/ausblenden</value></data>
+  <!-- Research History View -->
+  <data name="ResearchHistory_Title" xml:space="preserve"><value>Rechercheverlauf</value></data>
+  <data name="ResearchHistory_SearchPlaceholder" xml:space="preserve"><value>Recherchen durchsuchen...</value></data>
+  <data name="ResearchHistory_DateColumn" xml:space="preserve"><value>Datum</value></data>
+  <data name="ResearchHistory_QueryColumn" xml:space="preserve"><value>Forschungsfrage</value></data>
+  <data name="ResearchHistory_ProviderColumn" xml:space="preserve"><value>Anbieter</value></data>
+  <data name="ResearchHistory_StepsColumn" xml:space="preserve"><value>Schritte</value></data>
+  <data name="ResearchHistory_StatusColumn" xml:space="preserve"><value>Status</value></data>
+  <data name="ResearchHistory_NoSessions" xml:space="preserve"><value>Keine Recherchen gefunden</value></data>
+  <data name="ResearchHistory_Loading" xml:space="preserve"><value>Recherchen werden geladen...</value></data>
+  <data name="ResearchHistory_LoadMore" xml:space="preserve"><value>Mehr laden</value></data>
+  <data name="ResearchHistory_View" xml:space="preserve"><value>Anzeigen</value></data>
+  <data name="ResearchHistory_Export" xml:space="preserve"><value>Exportieren</value></data>
+  <data name="ResearchHistory_Delete" xml:space="preserve"><value>Löschen</value></data>
+  <data name="ResearchHistory_Refresh" xml:space="preserve"><value>Aktualisieren</value></data>
+  <data name="ResearchHistory_ClearFilters" xml:space="preserve"><value>Filter zurücksetzen</value></data>
+  <data name="ResearchHistory_DateRangeTo" xml:space="preserve"><value>bis</value></data>
+  <data name="ResearchHistory_ViewDetail" xml:space="preserve"><value>Details anzeigen</value></data>
+  <data name="ResearchHistory_CopyResult" xml:space="preserve"><value>Ergebnis kopieren</value></data>
+  <data name="Nav_ResearchHistory" xml:space="preserve"><value>Verlauf</value></data>
   <!-- History View -->
   <data name="History_Title" xml:space="preserve"><value>Verlauf</value></data>
   <data name="History_DateRangeTo" xml:space="preserve"><value>bis</value></data>

--- a/src/Pia.Wpf/Resources/Strings/ViewStrings.fr.resx
+++ b/src/Pia.Wpf/Resources/Strings/ViewStrings.fr.resx
@@ -103,6 +103,26 @@
   <data name="Research_ExportAll" xml:space="preserve"><value>Tout exporter</value></data>
   <data name="Research_NewResearch" xml:space="preserve"><value>Nouvelle recherche</value></data>
   <data name="Research_ToggleTodoPanel_Tooltip" xml:space="preserve"><value>Afficher/masquer le panneau des tâches</value></data>
+  <!-- Research History View -->
+  <data name="ResearchHistory_Title" xml:space="preserve"><value>Historique des recherches</value></data>
+  <data name="ResearchHistory_SearchPlaceholder" xml:space="preserve"><value>Rechercher dans les sessions...</value></data>
+  <data name="ResearchHistory_DateColumn" xml:space="preserve"><value>Date</value></data>
+  <data name="ResearchHistory_QueryColumn" xml:space="preserve"><value>Question de recherche</value></data>
+  <data name="ResearchHistory_ProviderColumn" xml:space="preserve"><value>Fournisseur</value></data>
+  <data name="ResearchHistory_StepsColumn" xml:space="preserve"><value>Étapes</value></data>
+  <data name="ResearchHistory_StatusColumn" xml:space="preserve"><value>Statut</value></data>
+  <data name="ResearchHistory_NoSessions" xml:space="preserve"><value>Aucune session de recherche trouvée</value></data>
+  <data name="ResearchHistory_Loading" xml:space="preserve"><value>Chargement des sessions de recherche...</value></data>
+  <data name="ResearchHistory_LoadMore" xml:space="preserve"><value>Charger plus</value></data>
+  <data name="ResearchHistory_View" xml:space="preserve"><value>Voir</value></data>
+  <data name="ResearchHistory_Export" xml:space="preserve"><value>Exporter</value></data>
+  <data name="ResearchHistory_Delete" xml:space="preserve"><value>Supprimer</value></data>
+  <data name="ResearchHistory_Refresh" xml:space="preserve"><value>Actualiser</value></data>
+  <data name="ResearchHistory_ClearFilters" xml:space="preserve"><value>Effacer les filtres</value></data>
+  <data name="ResearchHistory_DateRangeTo" xml:space="preserve"><value>au</value></data>
+  <data name="ResearchHistory_ViewDetail" xml:space="preserve"><value>Voir les détails</value></data>
+  <data name="ResearchHistory_CopyResult" xml:space="preserve"><value>Copier le résultat</value></data>
+  <data name="Nav_ResearchHistory" xml:space="preserve"><value>Historique</value></data>
   <!-- History View -->
   <data name="History_Title" xml:space="preserve"><value>Historique</value></data>
   <data name="History_DateRangeTo" xml:space="preserve"><value>au</value></data>

--- a/src/Pia.Wpf/Resources/Strings/ViewStrings.resx
+++ b/src/Pia.Wpf/Resources/Strings/ViewStrings.resx
@@ -103,6 +103,26 @@
   <data name="Research_ExportAll" xml:space="preserve"><value>Export All</value></data>
   <data name="Research_NewResearch" xml:space="preserve"><value>New Research</value></data>
   <data name="Research_ToggleTodoPanel_Tooltip" xml:space="preserve"><value>Toggle todo panel</value></data>
+  <!-- Research History View -->
+  <data name="ResearchHistory_Title" xml:space="preserve"><value>Research History</value></data>
+  <data name="ResearchHistory_SearchPlaceholder" xml:space="preserve"><value>Search research sessions...</value></data>
+  <data name="ResearchHistory_DateColumn" xml:space="preserve"><value>Date</value></data>
+  <data name="ResearchHistory_QueryColumn" xml:space="preserve"><value>Research Question</value></data>
+  <data name="ResearchHistory_ProviderColumn" xml:space="preserve"><value>Provider</value></data>
+  <data name="ResearchHistory_StepsColumn" xml:space="preserve"><value>Steps</value></data>
+  <data name="ResearchHistory_StatusColumn" xml:space="preserve"><value>Status</value></data>
+  <data name="ResearchHistory_NoSessions" xml:space="preserve"><value>No research sessions found</value></data>
+  <data name="ResearchHistory_Loading" xml:space="preserve"><value>Loading research sessions...</value></data>
+  <data name="ResearchHistory_LoadMore" xml:space="preserve"><value>Load More</value></data>
+  <data name="ResearchHistory_View" xml:space="preserve"><value>View</value></data>
+  <data name="ResearchHistory_Export" xml:space="preserve"><value>Export</value></data>
+  <data name="ResearchHistory_Delete" xml:space="preserve"><value>Delete</value></data>
+  <data name="ResearchHistory_Refresh" xml:space="preserve"><value>Refresh</value></data>
+  <data name="ResearchHistory_ClearFilters" xml:space="preserve"><value>Clear Filters</value></data>
+  <data name="ResearchHistory_DateRangeTo" xml:space="preserve"><value>to</value></data>
+  <data name="ResearchHistory_ViewDetail" xml:space="preserve"><value>View Detail</value></data>
+  <data name="ResearchHistory_CopyResult" xml:space="preserve"><value>Copy Result</value></data>
+  <data name="Nav_ResearchHistory" xml:space="preserve"><value>History</value></data>
   <!-- History View -->
   <data name="History_Title" xml:space="preserve"><value>History</value></data>
   <data name="History_DateRangeTo" xml:space="preserve"><value>to</value></data>

--- a/src/Pia.Wpf/Services/Interfaces/IResearchExportService.cs
+++ b/src/Pia.Wpf/Services/Interfaces/IResearchExportService.cs
@@ -1,0 +1,12 @@
+using Pia.Models;
+
+namespace Pia.Services.Interfaces;
+
+public interface IResearchExportService
+{
+    string BuildMarkdown(ResearchSession session);
+    string BuildHtml(ResearchSession session);
+    Task ExportAsMarkdownAsync(ResearchSession session, string filePath);
+    Task ExportAsHtmlAsync(ResearchSession session, string filePath);
+    Task ExportAsPdfAsync(ResearchSession session, string filePath);
+}

--- a/src/Pia.Wpf/Services/Interfaces/IResearchHistoryService.cs
+++ b/src/Pia.Wpf/Services/Interfaces/IResearchHistoryService.cs
@@ -1,0 +1,21 @@
+using Pia.Models;
+
+namespace Pia.Services.Interfaces;
+
+public interface IResearchHistoryService
+{
+    event EventHandler? SessionsChanged;
+    Task AddEntryAsync(ResearchHistoryEntry entry);
+    Task<IReadOnlyList<ResearchHistoryEntry>> SearchEntriesAsync(
+        string? searchText = null,
+        DateTime? fromDate = null,
+        DateTime? toDate = null,
+        int offset = 0,
+        int limit = 50);
+    Task<ResearchHistoryEntry?> GetEntryAsync(Guid id);
+    Task DeleteEntryAsync(Guid id);
+    Task<int> GetEntryCountAsync(
+        string? searchText = null,
+        DateTime? fromDate = null,
+        DateTime? toDate = null);
+}

--- a/src/Pia.Wpf/Services/ResearchExportService.cs
+++ b/src/Pia.Wpf/Services/ResearchExportService.cs
@@ -1,0 +1,186 @@
+using System.IO;
+using System.Printing;
+using System.Text;
+using System.Windows;
+using System.Windows.Documents;
+using System.Windows.Xps;
+using System.Windows.Xps.Packaging;
+using Markdig;
+using Pia.Models;
+using Pia.Services.Interfaces;
+
+namespace Pia.Services;
+
+public class ResearchExportService : IResearchExportService
+{
+    private static readonly MarkdownPipeline _pipeline = new MarkdownPipelineBuilder()
+        .UseAdvancedExtensions()
+        .Build();
+
+    public string BuildMarkdown(ResearchSession session)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"# Research: {session.Query}");
+        sb.AppendLine();
+        sb.AppendLine($"*{session.CreatedAt:f}*");
+        sb.AppendLine();
+
+        foreach (var step in session.Steps)
+        {
+            sb.AppendLine($"## Step {step.StepNumber}: {step.Title}");
+            sb.AppendLine();
+            sb.AppendLine(step.Content);
+            sb.AppendLine();
+        }
+
+        return sb.ToString();
+    }
+
+    public string BuildHtml(ResearchSession session)
+    {
+        var markdown = BuildMarkdown(session);
+        var htmlBody = Markdig.Markdown.ToHtml(markdown, _pipeline);
+
+        return $"""
+            <!DOCTYPE html>
+            <html lang="en">
+            <head>
+                <meta charset="UTF-8">
+                <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                <title>Research: {System.Net.WebUtility.HtmlEncode(session.Query)}</title>
+                <style>
+                    body {{
+                        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+                        line-height: 1.6;
+                        max-width: 900px;
+                        margin: 0 auto;
+                        padding: 2rem;
+                        color: #333;
+                    }}
+                    h1 {{ color: #1a1a2e; border-bottom: 2px solid #e0e0e0; padding-bottom: 0.3em; }}
+                    h2 {{ color: #16213e; margin-top: 1.5em; }}
+                    h3 {{ color: #0f3460; }}
+                    code {{
+                        background: #f4f4f4;
+                        padding: 0.2em 0.4em;
+                        border-radius: 3px;
+                        font-size: 0.9em;
+                    }}
+                    pre {{
+                        background: #f4f4f4;
+                        padding: 1em;
+                        border-radius: 6px;
+                        overflow-x: auto;
+                    }}
+                    pre code {{ background: transparent; padding: 0; }}
+                    blockquote {{
+                        border-left: 4px solid #4a90d9;
+                        margin: 1em 0;
+                        padding: 0.5em 1em;
+                        color: #555;
+                        background: #f8f9fa;
+                    }}
+                    table {{
+                        border-collapse: collapse;
+                        width: 100%;
+                        margin: 1em 0;
+                    }}
+                    th, td {{
+                        border: 1px solid #ddd;
+                        padding: 8px 12px;
+                        text-align: left;
+                    }}
+                    th {{ background: #f4f4f4; font-weight: 600; }}
+                </style>
+            </head>
+            <body>
+            {htmlBody}
+            </body>
+            </html>
+            """;
+    }
+
+    public async Task ExportAsMarkdownAsync(ResearchSession session, string filePath)
+    {
+        var markdown = BuildMarkdown(session);
+        await File.WriteAllTextAsync(filePath, markdown, Encoding.UTF8);
+    }
+
+    public async Task ExportAsHtmlAsync(ResearchSession session, string filePath)
+    {
+        var html = BuildHtml(session);
+        await File.WriteAllTextAsync(filePath, html, Encoding.UTF8);
+    }
+
+    public async Task ExportAsPdfAsync(ResearchSession session, string filePath)
+    {
+        var html = BuildHtml(session);
+
+        // Use WPF FlowDocument for PDF-like output via XPS
+        await Application.Current.Dispatcher.InvokeAsync(() =>
+        {
+            var flowDocument = new FlowDocument
+            {
+                PageWidth = 816, // 8.5" at 96 DPI
+                PageHeight = 1056, // 11" at 96 DPI
+                PagePadding = new Thickness(72), // 0.75" margins
+                ColumnWidth = double.MaxValue,
+                FontFamily = new System.Windows.Media.FontFamily("Segoe UI"),
+                FontSize = 13
+            };
+
+            BuildFlowDocument(flowDocument, session);
+
+            // Write to XPS first, then rename (XPS is close to PDF for local use)
+            var xpsPath = filePath;
+            using var xpsDocument = new XpsDocument(xpsPath, FileAccess.Write);
+            var writer = XpsDocument.CreateXpsDocumentWriter(xpsDocument);
+            writer.Write(((IDocumentPaginatorSource)flowDocument).DocumentPaginator);
+        });
+    }
+
+    private static void BuildFlowDocument(FlowDocument doc, ResearchSession session)
+    {
+        // Title
+        var title = new Paragraph(new Run($"Research: {session.Query}"))
+        {
+            FontSize = 24,
+            FontWeight = FontWeights.Bold,
+            Margin = new Thickness(0, 0, 0, 4)
+        };
+        doc.Blocks.Add(title);
+
+        // Date
+        var date = new Paragraph(new Run(session.CreatedAt.ToString("f")))
+        {
+            FontSize = 11,
+            Foreground = System.Windows.Media.Brushes.Gray,
+            Margin = new Thickness(0, 0, 0, 16)
+        };
+        doc.Blocks.Add(date);
+
+        // Steps
+        foreach (var step in session.Steps)
+        {
+            var heading = new Paragraph(new Run($"Step {step.StepNumber}: {step.Title}"))
+            {
+                FontSize = 18,
+                FontWeight = FontWeights.SemiBold,
+                Margin = new Thickness(0, 12, 0, 4)
+            };
+            doc.Blocks.Add(heading);
+
+            if (!string.IsNullOrWhiteSpace(step.Content))
+            {
+                foreach (var line in step.Content.Split('\n'))
+                {
+                    var para = new Paragraph(new Run(line))
+                    {
+                        Margin = new Thickness(0, 0, 0, 4)
+                    };
+                    doc.Blocks.Add(para);
+                }
+            }
+        }
+    }
+}

--- a/src/Pia.Wpf/Services/ResearchHistoryService.cs
+++ b/src/Pia.Wpf/Services/ResearchHistoryService.cs
@@ -1,0 +1,174 @@
+using Microsoft.Data.Sqlite;
+using Pia.Infrastructure;
+using Pia.Models;
+using Pia.Services.Interfaces;
+
+namespace Pia.Services;
+
+public class ResearchHistoryService : IResearchHistoryService
+{
+    private readonly SqliteContext _context;
+
+    public event EventHandler? SessionsChanged;
+
+    public ResearchHistoryService(SqliteContext context)
+    {
+        _context = context;
+    }
+
+    private void OnSessionsChanged() => SessionsChanged?.Invoke(this, EventArgs.Empty);
+
+    public async Task AddEntryAsync(ResearchHistoryEntry entry)
+    {
+        var connection = _context.GetConnection();
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            INSERT INTO ResearchSessions (Id, Query, SynthesizedResult, StepsJson, ProviderId, ProviderName,
+                                          Status, StepCount, CreatedAt, CompletedAt)
+            VALUES (@Id, @Query, @SynthesizedResult, @StepsJson, @ProviderId, @ProviderName,
+                    @Status, @StepCount, @CreatedAt, @CompletedAt)
+            """;
+
+        command.Parameters.AddWithValue("@Id", entry.Id.ToString());
+        command.Parameters.AddWithValue("@Query", entry.Query);
+        command.Parameters.AddWithValue("@SynthesizedResult", entry.SynthesizedResult);
+        command.Parameters.AddWithValue("@StepsJson", entry.StepsJson);
+        command.Parameters.AddWithValue("@ProviderId", entry.ProviderId.ToString());
+        command.Parameters.AddWithValue("@ProviderName", entry.ProviderName ?? (object)DBNull.Value);
+        command.Parameters.AddWithValue("@Status", entry.Status);
+        command.Parameters.AddWithValue("@StepCount", entry.StepCount);
+        command.Parameters.AddWithValue("@CreatedAt", entry.CreatedAt.ToString("O"));
+        command.Parameters.AddWithValue("@CompletedAt", entry.CompletedAt.ToString("O"));
+
+        await command.ExecuteNonQueryAsync();
+        OnSessionsChanged();
+    }
+
+    public async Task<IReadOnlyList<ResearchHistoryEntry>> SearchEntriesAsync(
+        string? searchText = null,
+        DateTime? fromDate = null,
+        DateTime? toDate = null,
+        int offset = 0,
+        int limit = 50)
+    {
+        var connection = _context.GetConnection();
+        using var command = connection.CreateCommand();
+
+        var whereClause = BuildWhereClause(command, searchText, fromDate, toDate);
+
+        command.CommandText = $"""
+            SELECT Id, Query, SynthesizedResult, StepsJson, ProviderId, ProviderName,
+                   Status, StepCount, CreatedAt, CompletedAt
+            FROM ResearchSessions
+            {whereClause}
+            ORDER BY CreatedAt DESC
+            LIMIT @Limit OFFSET @Offset
+            """;
+
+        command.Parameters.AddWithValue("@Limit", limit);
+        command.Parameters.AddWithValue("@Offset", offset);
+
+        var entries = new List<ResearchHistoryEntry>();
+        using var reader = await command.ExecuteReaderAsync();
+
+        while (await reader.ReadAsync())
+        {
+            entries.Add(MapEntry(reader));
+        }
+
+        return entries.AsReadOnly();
+    }
+
+    public async Task<ResearchHistoryEntry?> GetEntryAsync(Guid id)
+    {
+        var connection = _context.GetConnection();
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT Id, Query, SynthesizedResult, StepsJson, ProviderId, ProviderName,
+                   Status, StepCount, CreatedAt, CompletedAt
+            FROM ResearchSessions
+            WHERE Id = @Id
+            """;
+        command.Parameters.AddWithValue("@Id", id.ToString());
+
+        using var reader = await command.ExecuteReaderAsync();
+        if (await reader.ReadAsync())
+        {
+            return MapEntry(reader);
+        }
+
+        return null;
+    }
+
+    public async Task DeleteEntryAsync(Guid id)
+    {
+        var connection = _context.GetConnection();
+        using var command = connection.CreateCommand();
+        command.CommandText = "DELETE FROM ResearchSessions WHERE Id = @Id";
+        command.Parameters.AddWithValue("@Id", id.ToString());
+        await command.ExecuteNonQueryAsync();
+        OnSessionsChanged();
+    }
+
+    public async Task<int> GetEntryCountAsync(
+        string? searchText = null,
+        DateTime? fromDate = null,
+        DateTime? toDate = null)
+    {
+        var connection = _context.GetConnection();
+        using var command = connection.CreateCommand();
+
+        var whereClause = BuildWhereClause(command, searchText, fromDate, toDate);
+
+        command.CommandText = $"SELECT COUNT(*) FROM ResearchSessions {whereClause}";
+        var result = await command.ExecuteScalarAsync();
+        return Convert.ToInt32(result);
+    }
+
+    private static string BuildWhereClause(
+        SqliteCommand command,
+        string? searchText,
+        DateTime? fromDate,
+        DateTime? toDate)
+    {
+        var conditions = new List<string>();
+
+        if (!string.IsNullOrWhiteSpace(searchText))
+        {
+            conditions.Add("(Query LIKE @SearchText OR SynthesizedResult LIKE @SearchText)");
+            command.Parameters.AddWithValue("@SearchText", $"%{searchText}%");
+        }
+
+        if (fromDate.HasValue)
+        {
+            conditions.Add("CreatedAt >= @FromDate");
+            command.Parameters.AddWithValue("@FromDate", fromDate.Value.ToString("O"));
+        }
+
+        if (toDate.HasValue)
+        {
+            var endOfDay = toDate.Value.Date.AddDays(1).AddTicks(-1);
+            conditions.Add("CreatedAt <= @ToDate");
+            command.Parameters.AddWithValue("@ToDate", endOfDay.ToString("O"));
+        }
+
+        return conditions.Count > 0 ? $"WHERE {string.Join(" AND ", conditions)}" : "";
+    }
+
+    private static ResearchHistoryEntry MapEntry(SqliteDataReader reader)
+    {
+        return new ResearchHistoryEntry
+        {
+            Id = Guid.Parse(reader.GetString(0)),
+            Query = reader.GetString(1),
+            SynthesizedResult = reader.GetString(2),
+            StepsJson = reader.GetString(3),
+            ProviderId = Guid.Parse(reader.GetString(4)),
+            ProviderName = reader.IsDBNull(5) ? null : reader.GetString(5),
+            Status = reader.GetString(6),
+            StepCount = reader.GetInt32(7),
+            CreatedAt = DateTime.Parse(reader.GetString(8)),
+            CompletedAt = DateTime.Parse(reader.GetString(9))
+        };
+    }
+}

--- a/src/Pia.Wpf/Services/ResearchService.cs
+++ b/src/Pia.Wpf/Services/ResearchService.cs
@@ -62,7 +62,7 @@ public class ResearchService : IResearchService
                 researchStep.IsStreaming = true;
 
                 conversationHistory.Add(new ChatMessage(ChatRole.User,
-                    $"Now research and provide a detailed answer to this sub-question: {subQuestion}"));
+                    $"Now research and provide a detailed answer to this sub-question. Use Markdown formatting (headings, lists, bold, code blocks) for clarity: {subQuestion}"));
 
                 await foreach (var token in _aiClientService.StreamChatCompletionAsync(conversationHistory, provider, ct))
                 {
@@ -86,7 +86,7 @@ public class ResearchService : IResearchService
             synthesizeStep.IsStreaming = true;
 
             conversationHistory.Add(new ChatMessage(ChatRole.User,
-                "Now synthesize all the research findings above into a comprehensive, well-structured answer to the original question. Use clear headings and organize the information logically. Include key findings, conclusions, and any important caveats."));
+                "Now synthesize all the research findings above into a comprehensive, well-structured answer to the original question. Format your response in Markdown with clear headings (##), bullet points, bold key terms, and code blocks where appropriate. Organize the information logically. Include key findings, conclusions, and any important caveats."));
 
             await foreach (var token in _aiClientService.StreamChatCompletionAsync(conversationHistory, provider, ct))
             {

--- a/src/Pia.Wpf/ViewModels/MainWindowViewModel.cs
+++ b/src/Pia.Wpf/ViewModels/MainWindowViewModel.cs
@@ -239,13 +239,14 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
             {
                 WindowMode.Optimize => "History",
                 WindowMode.Assistant => "Memory",
-                WindowMode.Research => "Settings",
+                WindowMode.Research => "ResearchHistory",
                 _ => null
             },
             "Shortcut3" => Mode switch
             {
                 WindowMode.Optimize => "Settings",
                 WindowMode.Assistant => "Reminders",
+                WindowMode.Research => "Settings",
                 _ => null
             },
             "Shortcut4" => Mode switch
@@ -272,6 +273,9 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable
                 break;
             case "Research":
                 _navigationService.NavigateTo<ResearchViewModel>();
+                break;
+            case "ResearchHistory":
+                _navigationService.NavigateTo<ResearchHistoryViewModel>();
                 break;
             case "Memory":
                 _navigationService.NavigateTo<MemoryViewModel>();

--- a/src/Pia.Wpf/ViewModels/ResearchHistoryViewModel.cs
+++ b/src/Pia.Wpf/ViewModels/ResearchHistoryViewModel.cs
@@ -1,0 +1,416 @@
+using System.Collections.ObjectModel;
+using System.Text.Json;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.Logging;
+using Microsoft.Win32;
+using Pia.Models;
+using Pia.Navigation;
+using Pia.Services.Interfaces;
+
+namespace Pia.ViewModels;
+
+public partial class ResearchHistoryViewModel : ObservableObject, IDisposable, INavigationAware
+{
+    private readonly ILogger<ResearchHistoryViewModel> _logger;
+    private readonly IResearchHistoryService _researchHistoryService;
+    private readonly IResearchExportService _exportService;
+    private readonly IOutputService _outputService;
+    private readonly IDialogService _dialogService;
+    private readonly ILocalizationService _localizationService;
+    private CancellationTokenSource? _debounceCts;
+    private int _currentOffset;
+    private bool _disposed;
+
+    [ObservableProperty]
+    private ObservableCollection<ResearchHistoryEntry> _entries = new();
+
+    [ObservableProperty]
+    private DateTime? _filterStartDate;
+
+    [ObservableProperty]
+    private DateTime? _filterEndDate;
+
+    [ObservableProperty]
+    private string _searchQuery = string.Empty;
+
+    [ObservableProperty]
+    private bool _isLoading;
+
+    [ObservableProperty]
+    private int _totalCount;
+
+    [ObservableProperty]
+    private ResearchHistoryEntry? _selectedEntry;
+
+    [ObservableProperty]
+    private bool _isDetailOpen;
+
+    [ObservableProperty]
+    private ResearchHistoryEntry? _detailEntry;
+
+    [ObservableProperty]
+    private ObservableCollection<ResearchStepDto> _detailSteps = new();
+
+    public IAsyncRelayCommand ViewDetailCommand { get; }
+    public IAsyncRelayCommand CopyResultCommand { get; }
+    public IAsyncRelayCommand ExportEntryCommand { get; }
+    public IAsyncRelayCommand DeleteEntryCommand { get; }
+    public IAsyncRelayCommand RefreshCommand { get; }
+    public IAsyncRelayCommand ClearFilterCommand { get; }
+    public IAsyncRelayCommand LoadMoreCommand { get; }
+    public IRelayCommand CloseDetailCommand { get; }
+
+    public ResearchHistoryViewModel(
+        ILogger<ResearchHistoryViewModel> logger,
+        IResearchHistoryService researchHistoryService,
+        IResearchExportService exportService,
+        IOutputService outputService,
+        IDialogService dialogService,
+        ILocalizationService localizationService)
+    {
+        _logger = logger;
+        _researchHistoryService = researchHistoryService;
+        _exportService = exportService;
+        _outputService = outputService;
+        _dialogService = dialogService;
+        _localizationService = localizationService;
+
+        ViewDetailCommand = new AsyncRelayCommand(ExecuteViewDetailAsync, CanExecuteAction);
+        CopyResultCommand = new AsyncRelayCommand(ExecuteCopyResult, CanExecuteAction);
+        ExportEntryCommand = new AsyncRelayCommand(ExecuteExportEntry, CanExecuteAction);
+        DeleteEntryCommand = new AsyncRelayCommand(ExecuteDeleteEntry, CanExecuteAction);
+        RefreshCommand = new AsyncRelayCommand(ExecuteRefreshAsync);
+        ClearFilterCommand = new AsyncRelayCommand(ExecuteClearFilterAsync);
+        LoadMoreCommand = new AsyncRelayCommand(ExecuteLoadMore, CanLoadMore);
+        CloseDetailCommand = new RelayCommand(ExecuteCloseDetail);
+
+        PropertyChanged += OnPropertyChanged;
+        _researchHistoryService.SessionsChanged += OnSessionsChanged;
+    }
+
+    public void OnNavigatedTo(object? parameter) { }
+
+    public async Task OnNavigatedToAsync(object? parameter)
+    {
+        try
+        {
+            if (Entries.Count > 0)
+                return;
+
+            FilterStartDate = DateTime.Today.AddDays(-30);
+            FilterEndDate = DateTime.Today;
+
+            await LoadEntriesAsync(0, 50);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to initialize ResearchHistoryViewModel");
+        }
+    }
+
+    public void OnNavigatedFrom() { }
+
+    private async Task LoadEntriesAsync(int offset, int take)
+    {
+        try
+        {
+            IsLoading = true;
+
+            var entries = await _researchHistoryService.SearchEntriesAsync(
+                searchText: SearchQuery,
+                fromDate: FilterStartDate,
+                toDate: FilterEndDate,
+                offset: offset,
+                limit: take);
+
+            if (offset == 0)
+            {
+                Entries.Clear();
+            }
+
+            foreach (var entry in entries)
+            {
+                Entries.Add(entry);
+            }
+
+            _currentOffset = offset + entries.Count;
+
+            TotalCount = await _researchHistoryService.GetEntryCountAsync(
+                searchText: SearchQuery,
+                fromDate: FilterStartDate,
+                toDate: FilterEndDate);
+
+            UpdateCommandStates();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load research entries (offset: {Offset}, take: {Take})", offset, take);
+        }
+        finally
+        {
+            IsLoading = false;
+        }
+    }
+
+    private async Task ExecuteViewDetailAsync()
+    {
+        if (SelectedEntry is null)
+            return;
+
+        DetailEntry = SelectedEntry;
+        DetailSteps.Clear();
+
+        try
+        {
+            var steps = JsonSerializer.Deserialize<List<ResearchStepDto>>(SelectedEntry.StepsJson);
+            if (steps is not null)
+            {
+                foreach (var step in steps)
+                {
+                    DetailSteps.Add(step);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to parse steps JSON");
+        }
+
+        IsDetailOpen = true;
+    }
+
+    private void ExecuteCloseDetail()
+    {
+        IsDetailOpen = false;
+        DetailEntry = null;
+        DetailSteps.Clear();
+    }
+
+    private async Task ExecuteCopyResult()
+    {
+        if (SelectedEntry is null)
+            return;
+
+        try
+        {
+            await _outputService.CopyToClipboardAsync(SelectedEntry.SynthesizedResult);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to copy result to clipboard");
+        }
+    }
+
+    private async Task ExecuteExportEntry()
+    {
+        if (SelectedEntry is null)
+            return;
+
+        try
+        {
+            // Reconstruct a ResearchSession from the history entry for export
+            var session = ReconstructSession(SelectedEntry);
+
+            var dialog = new SaveFileDialog
+            {
+                Title = _localizationService["ResearchHistory_Export"],
+                FileName = $"Research_{SelectedEntry.CreatedAt:yyyyMMdd_HHmmss}",
+                Filter = "Markdown (*.md)|*.md|HTML (*.html)|*.html|PDF (*.xps)|*.xps",
+                FilterIndex = 1,
+                DefaultExt = ".md"
+            };
+
+            if (dialog.ShowDialog() != true)
+                return;
+
+            switch (dialog.FilterIndex)
+            {
+                case 1:
+                    await _exportService.ExportAsMarkdownAsync(session, dialog.FileName);
+                    break;
+                case 2:
+                    await _exportService.ExportAsHtmlAsync(session, dialog.FileName);
+                    break;
+                case 3:
+                    await _exportService.ExportAsPdfAsync(session, dialog.FileName);
+                    break;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to export research entry");
+        }
+    }
+
+    private async Task ExecuteDeleteEntry()
+    {
+        if (SelectedEntry is null)
+            return;
+
+        var confirmed = await _dialogService.ShowConfirmationDialogAsync(
+            _localizationService["Msg_ResearchHistory_ConfirmDeleteTitle"],
+            _localizationService["Msg_ResearchHistory_ConfirmDeleteMessage"]);
+
+        if (!confirmed)
+            return;
+
+        var entry = SelectedEntry;
+
+        try
+        {
+            await _researchHistoryService.DeleteEntryAsync(entry.Id);
+            Entries.Remove(entry);
+            SelectedEntry = null;
+
+            if (IsDetailOpen && DetailEntry?.Id == entry.Id)
+            {
+                ExecuteCloseDetail();
+            }
+
+            TotalCount = await _researchHistoryService.GetEntryCountAsync(
+                searchText: SearchQuery,
+                fromDate: FilterStartDate,
+                toDate: FilterEndDate);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to delete research entry {EntryId}", entry.Id);
+            await _dialogService.ShowMessageDialogAsync(
+                _localizationService["Msg_Error"],
+                _localizationService.Format("Msg_ResearchHistory_DeleteFailed", ex.Message));
+        }
+    }
+
+    private async Task ExecuteRefreshAsync()
+    {
+        await LoadEntriesAsync(0, 50);
+    }
+
+    private async Task ExecuteClearFilterAsync()
+    {
+        FilterStartDate = null;
+        FilterEndDate = null;
+        SearchQuery = string.Empty;
+        await LoadEntriesAsync(0, 50);
+    }
+
+    private async Task ExecuteLoadMore()
+    {
+        await LoadEntriesAsync(_currentOffset, 50);
+    }
+
+    private bool CanExecuteAction() => SelectedEntry is not null && !IsLoading;
+
+    private bool CanLoadMore() => !IsLoading && Entries.Count < TotalCount;
+
+    private void UpdateCommandStates()
+    {
+        ViewDetailCommand.NotifyCanExecuteChanged();
+        CopyResultCommand.NotifyCanExecuteChanged();
+        ExportEntryCommand.NotifyCanExecuteChanged();
+        DeleteEntryCommand.NotifyCanExecuteChanged();
+        LoadMoreCommand.NotifyCanExecuteChanged();
+    }
+
+    private void DebounceSearch()
+    {
+        _debounceCts?.Cancel();
+        _debounceCts = new CancellationTokenSource();
+        var token = _debounceCts.Token;
+        SafeFireAndForget(DebounceAsync(500, () => LoadEntriesAsync(0, 50), token));
+    }
+
+    private static async Task DebounceAsync(int delayMs, Func<Task> action, CancellationToken ct)
+    {
+        await Task.Delay(delayMs, ct);
+        await action();
+    }
+
+    private async void SafeFireAndForget(Task task)
+    {
+        try { await task; }
+        catch (OperationCanceledException) { }
+        catch (Exception ex) { _logger.LogError(ex, "Background operation failed"); }
+    }
+
+    private void OnSessionsChanged(object? sender, EventArgs e)
+    {
+        System.Windows.Application.Current.Dispatcher.InvokeAsync(() =>
+            SafeFireAndForget(LoadEntriesAsync(0, 50)));
+    }
+
+    private void OnPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(SelectedEntry))
+        {
+            UpdateCommandStates();
+        }
+
+        if (e.PropertyName == nameof(SearchQuery))
+        {
+            DebounceSearch();
+        }
+
+        if (e.PropertyName is nameof(FilterStartDate) or nameof(FilterEndDate))
+        {
+            DebounceSearch();
+        }
+
+        if (e.PropertyName == nameof(IsLoading))
+        {
+            UpdateCommandStates();
+        }
+    }
+
+    private static ResearchSession ReconstructSession(ResearchHistoryEntry entry)
+    {
+        var session = new ResearchSession(entry.Query);
+
+        try
+        {
+            var steps = JsonSerializer.Deserialize<List<ResearchStepDto>>(entry.StepsJson);
+            if (steps is not null)
+            {
+                foreach (var stepDto in steps)
+                {
+                    var step = new ResearchStep(stepDto.StepNumber, stepDto.Title)
+                    {
+                        Content = stepDto.Content,
+                        Status = Enum.TryParse<ResearchStatus>(stepDto.Status, out var status)
+                            ? status
+                            : ResearchStatus.Completed
+                    };
+                    session.Steps.Add(step);
+                }
+            }
+        }
+        catch
+        {
+            // If deserialization fails, return session with no steps
+        }
+
+        session.SynthesizedResult = entry.SynthesizedResult;
+        session.Status = Enum.TryParse<ResearchStatus>(entry.Status, out var s)
+            ? s
+            : ResearchStatus.Completed;
+
+        return session;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+
+        _debounceCts?.Cancel();
+        _debounceCts?.Dispose();
+
+        _researchHistoryService.SessionsChanged -= OnSessionsChanged;
+        PropertyChanged -= OnPropertyChanged;
+
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/Pia.Wpf/ViewModels/ResearchViewModel.cs
+++ b/src/Pia.Wpf/ViewModels/ResearchViewModel.cs
@@ -1,7 +1,9 @@
 using System.Text;
+using System.Text.Json;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Extensions.Logging;
+using Microsoft.Win32;
 using Pia.Models;
 using Pia.Navigation;
 using Pia.Services.Interfaces;
@@ -14,6 +16,8 @@ public partial class ResearchViewModel : ObservableObject, INavigationAware, IDi
     private readonly IProviderService _providerService;
     private readonly IOutputService _outputService;
     private readonly IVoiceInputService _voiceInputService;
+    private readonly IResearchExportService _exportService;
+    private readonly IResearchHistoryService _researchHistoryService;
     private readonly Wpf.Ui.ISnackbarService _snackbarService;
     private readonly ILocalizationService _localizationService;
     private readonly ILogger<ResearchViewModel> _logger;
@@ -44,6 +48,8 @@ public partial class ResearchViewModel : ObservableObject, INavigationAware, IDi
         IProviderService providerService,
         IOutputService outputService,
         IVoiceInputService voiceInputService,
+        IResearchExportService exportService,
+        IResearchHistoryService researchHistoryService,
         Wpf.Ui.ISnackbarService snackbarService,
         ILocalizationService localizationService,
         ILogger<ResearchViewModel> logger)
@@ -52,6 +58,8 @@ public partial class ResearchViewModel : ObservableObject, INavigationAware, IDi
         _providerService = providerService;
         _outputService = outputService;
         _voiceInputService = voiceInputService;
+        _exportService = exportService;
+        _researchHistoryService = researchHistoryService;
         _snackbarService = snackbarService;
         _localizationService = localizationService;
         _logger = logger;
@@ -98,6 +106,9 @@ public partial class ResearchViewModel : ObservableObject, INavigationAware, IDi
         try
         {
             await _researchService.ExecuteResearchAsync(session, provider, _researchCts.Token);
+
+            // Save completed session to history
+            await SaveSessionToHistoryAsync(session, provider);
         }
         catch (OperationCanceledException)
         {
@@ -157,20 +168,38 @@ public partial class ResearchViewModel : ObservableObject, INavigationAware, IDi
 
         try
         {
-            var sb = new StringBuilder();
-            sb.AppendLine($"# Research: {CurrentSession.Query}");
-            sb.AppendLine();
-
-            foreach (var step in CurrentSession.Steps)
+            var dialog = new SaveFileDialog
             {
-                sb.AppendLine($"## Step {step.StepNumber}: {step.Title}");
-                sb.AppendLine();
-                sb.AppendLine(step.Content);
-                sb.AppendLine();
+                Title = _localizationService["Research_ExportAll"],
+                FileName = $"Research_{CurrentSession.CreatedAt:yyyyMMdd_HHmmss}",
+                Filter = "Markdown (*.md)|*.md|HTML (*.html)|*.html|PDF (*.xps)|*.xps",
+                FilterIndex = 1,
+                DefaultExt = ".md"
+            };
+
+            if (dialog.ShowDialog() != true)
+                return;
+
+            var filePath = dialog.FileName;
+            var filterIndex = dialog.FilterIndex;
+
+            switch (filterIndex)
+            {
+                case 1: // Markdown
+                    await _exportService.ExportAsMarkdownAsync(CurrentSession, filePath);
+                    break;
+                case 2: // HTML
+                    await _exportService.ExportAsHtmlAsync(CurrentSession, filePath);
+                    break;
+                case 3: // PDF/XPS
+                    await _exportService.ExportAsPdfAsync(CurrentSession, filePath);
+                    break;
             }
 
-            await _outputService.CopyToClipboardAsync(sb.ToString());
-            _snackbarService.Show(_localizationService["Msg_Research_Exported"], _localizationService["Msg_Research_FullResearchExported"], Wpf.Ui.Controls.ControlAppearance.Success, null, TimeSpan.FromSeconds(2));
+            _snackbarService.Show(
+                _localizationService["Msg_Research_Exported"],
+                _localizationService.Format("Msg_Research_ExportedToFile", filePath),
+                Wpf.Ui.Controls.ControlAppearance.Success, null, TimeSpan.FromSeconds(3));
         }
         catch (Exception ex)
         {
@@ -185,6 +214,38 @@ public partial class ResearchViewModel : ObservableObject, INavigationAware, IDi
         QueryText = string.Empty;
         ErrorMessage = null;
         IsResearching = false;
+    }
+
+    private async Task SaveSessionToHistoryAsync(ResearchSession session, AiProvider provider)
+    {
+        try
+        {
+            var historyEntry = new ResearchHistoryEntry
+            {
+                Id = session.Id,
+                Query = session.Query,
+                SynthesizedResult = session.SynthesizedResult,
+                StepsJson = JsonSerializer.Serialize(
+                    session.Steps.Select(s => new ResearchStepDto
+                    {
+                        StepNumber = s.StepNumber,
+                        Title = s.Title,
+                        Content = s.Content,
+                        Status = s.Status.ToString()
+                    }).ToList()),
+                ProviderId = provider.Id,
+                ProviderName = provider.Name,
+                Status = session.Status.ToString(),
+                StepCount = session.Steps.Count,
+                CreatedAt = session.CreatedAt,
+                CompletedAt = session.CompletedAt ?? DateTime.Now
+            };
+            await _researchHistoryService.AddEntryAsync(historyEntry);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to save research session to history");
+        }
     }
 
     public void OnNavigatedTo(object? parameter)

--- a/src/Pia.Wpf/Views/NavigationSidebarView.xaml
+++ b/src/Pia.Wpf/Views/NavigationSidebarView.xaml
@@ -58,6 +58,17 @@
         </ui:NavigationViewItem.Icon>
       </ui:NavigationViewItem>
 
+      <!-- Research History (Research only) -->
+      <ui:NavigationViewItem Content="{loc:Str Nav_ResearchHistory}"
+                             Command="{Binding NavigationCommand}"
+                             CommandParameter="ResearchHistory"
+                             IsActive="{Binding CurrentNavigationItem, Converter={StaticResource StringEqualsBoolConverter}, ConverterParameter=ResearchHistory}"
+                             Visibility="{Binding Mode, Converter={StaticResource WindowModeToVisibilityConverter}, ConverterParameter=Research}">
+        <ui:NavigationViewItem.Icon>
+          <ui:SymbolIcon Symbol="Clock24" />
+        </ui:NavigationViewItem.Icon>
+      </ui:NavigationViewItem>
+
       <!-- Memory (Assistant only) -->
       <ui:NavigationViewItem Content="{loc:Str Nav_Memory}"
                              Command="{Binding NavigationCommand}"

--- a/src/Pia.Wpf/Views/ResearchHistoryView.xaml
+++ b/src/Pia.Wpf/Views/ResearchHistoryView.xaml
@@ -1,0 +1,395 @@
+<UserControl x:Class="Pia.Views.ResearchHistoryView"
+              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+              xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+              xmlns:controls="clr-namespace:Pia.Controls"
+              xmlns:loc="clr-namespace:Pia.Localization"
+              xmlns:nav="clr-namespace:Pia.Navigation"
+              mc:Ignorable="d"
+              d:DesignHeight="600" d:DesignWidth="900"
+              nav:ViewModelLocator.AutoWireViewModel="True">
+
+  <Grid Background="{DynamicResource PrimaryBackgroundBrush}"
+        Margin="20,45,20,20">
+    <Grid.RowDefinitions>
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="*" />
+      <RowDefinition Height="Auto" />
+    </Grid.RowDefinitions>
+
+    <TextBlock Grid.Row="0"
+               Text="{loc:Str ResearchHistory_Title}"
+               Style="{StaticResource H1TextStyle}"
+               Margin="20,20,20,10" />
+
+    <!-- Filters -->
+    <Border Grid.Row="1"
+            Background="{DynamicResource SecondaryBackgroundBrush}"
+            BorderBrush="{DynamicResource CardBorderBrush}"
+            BorderThickness="1"
+            CornerRadius="4"
+            Margin="20,0,20,10"
+            Padding="10">
+      <Grid>
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition Width="Auto" />
+          <ColumnDefinition Width="Auto" />
+          <ColumnDefinition Width="Auto" />
+          <ColumnDefinition Width="*" />
+          <ColumnDefinition Width="Auto" />
+          <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
+
+        <DatePicker Grid.Column="0"
+                   SelectedDate="{Binding FilterStartDate}"
+                   Width="180"
+                   Margin="0,0,4,0" />
+
+        <TextBlock Grid.Column="1"
+                  Text="{loc:Str ResearchHistory_DateRangeTo}"
+                  VerticalAlignment="Center"
+                  Margin="0,0,4,0" />
+
+        <DatePicker Grid.Column="2"
+                   SelectedDate="{Binding FilterEndDate}"
+                   Width="180"
+                   Margin="0,0,8,0" />
+
+        <ui:TextBox Grid.Column="3"
+                    Text="{Binding SearchQuery, UpdateSourceTrigger=PropertyChanged}"
+                    PlaceholderText="{loc:Str ResearchHistory_SearchPlaceholder}"
+                    PlaceholderEnabled="True"
+                    ClearButtonEnabled="False"
+                    MinWidth="100"
+                    Margin="0,0,8,0" />
+
+        <ui:Button Grid.Column="4"
+                   Command="{Binding RefreshCommand}"
+                   Appearance="Secondary"
+                   Width="36"
+                   Height="36"
+                   Padding="0"
+                   Margin="0,0,4,0"
+                   ToolTip="{loc:Str ResearchHistory_Refresh}">
+          <Grid>
+            <ui:SymbolIcon Symbol="ArrowSync24" FontSize="16"
+                           Visibility="{Binding IsLoading, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
+            <ui:ProgressRing IsIndeterminate="True"
+                             Width="16" Height="16"
+                             Visibility="{Binding IsLoading, Converter={StaticResource BooleanToVisibilityConverter}}" />
+          </Grid>
+        </ui:Button>
+
+        <ui:Button Grid.Column="5"
+                   Command="{Binding ClearFilterCommand}"
+                   Appearance="Secondary"
+                   Width="36"
+                   Height="36"
+                   Padding="0"
+                   ToolTip="{loc:Str ResearchHistory_ClearFilters}">
+          <ui:SymbolIcon Symbol="FilterDismiss24" FontSize="16" />
+        </ui:Button>
+      </Grid>
+    </Border>
+
+    <!-- Main Content: List + Detail -->
+    <Grid Grid.Row="2" Margin="20,0,20,10">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="*" MinWidth="300" />
+        <ColumnDefinition Width="Auto" />
+        <ColumnDefinition Width="1.5*">
+          <ColumnDefinition.Style>
+            <Style TargetType="ColumnDefinition">
+              <Setter Property="Width" Value="0" />
+              <Style.Triggers>
+                <DataTrigger Binding="{Binding IsDetailOpen}" Value="True">
+                  <Setter Property="Width" Value="1.5*" />
+                </DataTrigger>
+              </Style.Triggers>
+            </Style>
+          </ColumnDefinition.Style>
+        </ColumnDefinition>
+      </Grid.ColumnDefinitions>
+
+      <!-- Session List -->
+      <ListBox Grid.Column="0"
+               ItemsSource="{Binding Entries}"
+               SelectedItem="{Binding SelectedEntry}"
+               Background="{DynamicResource PrimaryBackgroundBrush}"
+               BorderBrush="{DynamicResource CardBorderBrush}"
+               BorderThickness="1"
+               VirtualizingPanel.IsVirtualizing="True"
+               VirtualizingPanel.VirtualizationMode="Recycling"
+               ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+        <ListBox.InputBindings>
+          <MouseBinding MouseAction="LeftDoubleClick" Command="{Binding ViewDetailCommand}" />
+        </ListBox.InputBindings>
+        <ListBox.ContextMenu>
+          <ContextMenu Background="{DynamicResource SecondaryBackgroundBrush}">
+            <MenuItem Header="{loc:Str ResearchHistory_ViewDetail}" Command="{Binding ViewDetailCommand}">
+              <MenuItem.Icon>
+                <ui:SymbolIcon Symbol="Eye24" FontSize="16"/>
+              </MenuItem.Icon>
+            </MenuItem>
+            <MenuItem Header="{loc:Str ResearchHistory_CopyResult}" Command="{Binding CopyResultCommand}">
+              <MenuItem.Icon>
+                <ui:SymbolIcon Symbol="Copy24" FontSize="16"/>
+              </MenuItem.Icon>
+            </MenuItem>
+            <MenuItem Header="{loc:Str ResearchHistory_Export}" Command="{Binding ExportEntryCommand}">
+              <MenuItem.Icon>
+                <ui:SymbolIcon Symbol="ArrowExportUp24" FontSize="16"/>
+              </MenuItem.Icon>
+            </MenuItem>
+            <Separator />
+            <MenuItem Header="{loc:Str ResearchHistory_Delete}" Command="{Binding DeleteEntryCommand}">
+              <MenuItem.Icon>
+                <ui:SymbolIcon Symbol="Delete24" FontSize="16"/>
+              </MenuItem.Icon>
+            </MenuItem>
+          </ContextMenu>
+        </ListBox.ContextMenu>
+        <ListBox.ItemTemplate>
+          <DataTemplate>
+            <Border Padding="12,10"
+                    Margin="0,0,0,2">
+              <Grid>
+                <Grid.RowDefinitions>
+                  <RowDefinition Height="Auto" />
+                  <RowDefinition Height="Auto" />
+                  <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+
+                <!-- Date + Status Row -->
+                <Grid Grid.Row="0" Margin="0,0,0,4">
+                  <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                  </Grid.ColumnDefinitions>
+                  <TextBlock Grid.Column="0"
+                             Text="{Binding CreatedAt, StringFormat='{}{0:g}'}"
+                             FontSize="11"
+                             Foreground="{DynamicResource TextPlaceholderColorBrush}" />
+                  <TextBlock Grid.Column="1"
+                             Text="{Binding ProviderName}"
+                             FontSize="11"
+                             Foreground="{DynamicResource TextPlaceholderColorBrush}"
+                             Margin="8,0" />
+                  <Border Grid.Column="2"
+                          Background="{DynamicResource AccentFillColorDefaultBrush}"
+                          CornerRadius="8"
+                          Padding="6,2">
+                    <TextBlock Text="{Binding StepCount, StringFormat='{}{0} steps'}"
+                               FontSize="10"
+                               Foreground="White" />
+                  </Border>
+                </Grid>
+
+                <!-- Query -->
+                <TextBlock Grid.Row="1"
+                           Text="{Binding Query}"
+                           FontSize="13"
+                           FontWeight="SemiBold"
+                           TextWrapping="Wrap"
+                           TextTrimming="CharacterEllipsis"
+                           MaxHeight="40"
+                           Margin="0,0,0,4" />
+
+                <!-- Result Preview -->
+                <TextBlock Grid.Row="2"
+                           Text="{Binding ResultPreview}"
+                           FontSize="12"
+                           Foreground="{DynamicResource TextPlaceholderColorBrush}"
+                           TextWrapping="Wrap"
+                           TextTrimming="CharacterEllipsis"
+                           MaxHeight="36" />
+              </Grid>
+            </Border>
+          </DataTemplate>
+        </ListBox.ItemTemplate>
+      </ListBox>
+
+      <!-- Splitter -->
+      <GridSplitter Grid.Column="1"
+                    Width="4"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Stretch"
+                    Background="Transparent"
+                    Visibility="{Binding IsDetailOpen, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
+      <!-- Detail Panel -->
+      <Border Grid.Column="2"
+              Background="{DynamicResource SecondaryBackgroundBrush}"
+              BorderBrush="{DynamicResource CardBorderBrush}"
+              BorderThickness="1"
+              CornerRadius="4"
+              Visibility="{Binding IsDetailOpen, Converter={StaticResource BooleanToVisibilityConverter}}">
+        <Grid>
+          <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+          </Grid.RowDefinitions>
+
+          <!-- Detail Header -->
+          <Border Grid.Row="0"
+                  BorderThickness="0,0,0,1"
+                  BorderBrush="{DynamicResource ControlStrokeColorDefaultBrush}"
+                  Padding="16,10">
+            <Grid>
+              <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+              </Grid.ColumnDefinitions>
+              <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                <TextBlock Text="{Binding DetailEntry.CreatedAt, StringFormat='{}{0:f}'}"
+                           FontSize="11"
+                           Foreground="{DynamicResource TextPlaceholderColorBrush}"
+                           Margin="0,0,0,2" />
+                <TextBlock Text="{Binding DetailEntry.Query}"
+                           FontSize="14"
+                           FontWeight="SemiBold"
+                           TextWrapping="Wrap"
+                           TextTrimming="CharacterEllipsis"
+                           MaxHeight="60" />
+              </StackPanel>
+              <ui:Button Grid.Column="1"
+                         Command="{Binding CloseDetailCommand}"
+                         Appearance="Secondary"
+                         Width="32"
+                         Height="32"
+                         Padding="0">
+                <ui:SymbolIcon Symbol="Dismiss24" FontSize="16" />
+              </ui:Button>
+            </Grid>
+          </Border>
+
+          <!-- Detail Content: Steps with Markdown -->
+          <ScrollViewer Grid.Row="1"
+                        VerticalScrollBarVisibility="Auto"
+                        HorizontalScrollBarVisibility="Disabled"
+                        Padding="16,8">
+            <ItemsControl ItemsSource="{Binding DetailSteps}">
+              <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                  <Border Margin="0,0,0,12"
+                          Padding="12,8"
+                          CornerRadius="6"
+                          Background="{DynamicResource ControlFillColorSecondaryBrush}"
+                          BorderBrush="{DynamicResource ControlStrokeColorDefaultBrush}"
+                          BorderThickness="1">
+                    <StackPanel>
+                      <StackPanel Orientation="Horizontal" Margin="0,0,0,6">
+                        <Border Width="24"
+                                Height="24"
+                                CornerRadius="12"
+                                Background="{DynamicResource AccentFillColorDefaultBrush}"
+                                Margin="0,0,8,0">
+                          <TextBlock Text="{Binding StepNumber}"
+                                     HorizontalAlignment="Center"
+                                     VerticalAlignment="Center"
+                                     FontSize="11"
+                                     FontWeight="SemiBold"
+                                     Foreground="White" />
+                        </Border>
+                        <TextBlock Text="{Binding Title}"
+                                   FontSize="13"
+                                   FontWeight="SemiBold"
+                                   VerticalAlignment="Center"
+                                   TextWrapping="Wrap" />
+                      </StackPanel>
+                      <controls:MarkdownMessageControl MarkdownText="{Binding Content}"
+                                                        IsStreaming="False"
+                                                        Margin="32,0,0,0" />
+                    </StackPanel>
+                  </Border>
+                </DataTemplate>
+              </ItemsControl.ItemTemplate>
+            </ItemsControl>
+          </ScrollViewer>
+
+          <!-- Detail Actions -->
+          <Border Grid.Row="2"
+                  BorderThickness="0,1,0,0"
+                  BorderBrush="{DynamicResource ControlStrokeColorDefaultBrush}"
+                  Padding="16,8">
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+              <ui:Button Command="{Binding CopyResultCommand}"
+                         Appearance="Primary"
+                         Height="32"
+                         Margin="0,0,8,0"
+                         Padding="12,0">
+                <StackPanel Orientation="Horizontal">
+                  <ui:SymbolIcon Symbol="Copy24" FontSize="14" Margin="0,0,6,0" />
+                  <TextBlock Text="{loc:Str ResearchHistory_CopyResult}" VerticalAlignment="Center" FontSize="12" />
+                </StackPanel>
+              </ui:Button>
+              <ui:Button Command="{Binding ExportEntryCommand}"
+                         Appearance="Secondary"
+                         Height="32"
+                         Margin="0,0,8,0"
+                         Padding="12,0">
+                <StackPanel Orientation="Horizontal">
+                  <ui:SymbolIcon Symbol="ArrowExportUp24" FontSize="14" Margin="0,0,6,0" />
+                  <TextBlock Text="{loc:Str ResearchHistory_Export}" VerticalAlignment="Center" FontSize="12" />
+                </StackPanel>
+              </ui:Button>
+              <ui:Button Command="{Binding DeleteEntryCommand}"
+                         Appearance="Secondary"
+                         Height="32"
+                         Padding="12,0">
+                <StackPanel Orientation="Horizontal">
+                  <ui:SymbolIcon Symbol="Delete24" FontSize="14" Margin="0,0,6,0" />
+                  <TextBlock Text="{loc:Str ResearchHistory_Delete}" VerticalAlignment="Center" FontSize="12" />
+                </StackPanel>
+              </ui:Button>
+            </StackPanel>
+          </Border>
+        </Grid>
+      </Border>
+
+      <!-- Empty state overlay -->
+      <TextBlock Grid.Column="0"
+                 Text="{loc:Str ResearchHistory_NoSessions}"
+                 HorizontalAlignment="Center"
+                 VerticalAlignment="Center"
+                 FontSize="16"
+                 Visibility="{Binding Entries.Count, Converter={StaticResource ZeroToVisibilityConverter}}" />
+
+      <!-- Loading overlay -->
+      <StackPanel Grid.Column="0"
+                 Visibility="{Binding IsLoading, Converter={StaticResource BooleanToVisibilityConverter}}"
+                 Background="{DynamicResource PrimaryBackgroundBrush}"
+                 Opacity="0.8">
+        <TextBlock Text="{loc:Str ResearchHistory_Loading}"
+                   HorizontalAlignment="Center"
+                   VerticalAlignment="Center"
+                   FontSize="16"
+                   Margin="20" />
+      </StackPanel>
+    </Grid>
+
+    <!-- Load More -->
+    <StackPanel Grid.Row="3"
+               Orientation="Horizontal"
+               HorizontalAlignment="Center"
+               Margin="20">
+      <Button Command="{Binding LoadMoreCommand}"
+              Width="150"
+              Margin="5"
+              Visibility="{Binding IsLoading, Converter={StaticResource InverseBooleanToVisibilityConverter}}">
+        <StackPanel Orientation="Horizontal">
+          <ui:SymbolIcon Symbol="ChevronDown24" FontSize="16" Margin="0,0,8,0"/>
+          <TextBlock Text="{loc:Str ResearchHistory_LoadMore}"/>
+        </StackPanel>
+      </Button>
+      <TextBlock Text="{Binding TotalCount, StringFormat='Showing {0} sessions'}"
+                 VerticalAlignment="Center"
+                 Margin="10" />
+    </StackPanel>
+  </Grid>
+</UserControl>

--- a/src/Pia.Wpf/Views/ResearchHistoryView.xaml.cs
+++ b/src/Pia.Wpf/Views/ResearchHistoryView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Pia.Views;
+
+public partial class ResearchHistoryView : UserControl
+{
+    public ResearchHistoryView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Pia.Wpf/Views/ResearchView.xaml
+++ b/src/Pia.Wpf/Views/ResearchView.xaml
@@ -5,6 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
              xmlns:local="clr-namespace:Pia.Views"
+             xmlns:controls="clr-namespace:Pia.Controls"
              xmlns:models="clr-namespace:Pia.Models"
              xmlns:nav="clr-namespace:Pia.Navigation"
              xmlns:loc="clr-namespace:Pia.Localization"
@@ -282,17 +283,15 @@
                     </ContentControl.Style>
                   </ContentControl>
 
-                  <!-- Content (collapsed when Pending) -->
-                  <TextBlock Grid.Column="0"
-                             Grid.ColumnSpan="3"
-                             Grid.Row="1"
-                             Text="{Binding Content}"
-                             TextWrapping="Wrap"
-                             FontSize="13"
-                             Margin="40,8,0,0"
-                             Foreground="{DynamicResource TextSecondaryBrush}">
-                    <TextBlock.Style>
-                      <Style TargetType="TextBlock">
+                  <!-- Content (collapsed when Pending) - rendered as Markdown -->
+                  <controls:MarkdownMessageControl Grid.Column="0"
+                                                    Grid.ColumnSpan="3"
+                                                    Grid.Row="1"
+                                                    MarkdownText="{Binding Content}"
+                                                    IsStreaming="{Binding IsStreaming}"
+                                                    Margin="40,8,0,0">
+                    <controls:MarkdownMessageControl.Style>
+                      <Style TargetType="controls:MarkdownMessageControl">
                         <Setter Property="Visibility" Value="Visible" />
                         <Style.Triggers>
                           <DataTrigger Binding="{Binding Status}" Value="{x:Static models:ResearchStatus.Pending}">
@@ -300,8 +299,8 @@
                           </DataTrigger>
                         </Style.Triggers>
                       </Style>
-                    </TextBlock.Style>
-                  </TextBlock>
+                    </controls:MarkdownMessageControl.Style>
+                  </controls:MarkdownMessageControl>
                 </Grid>
               </Border>
             </DataTemplate>


### PR DESCRIPTION
- Replace plain TextBlock with MarkdownMessageControl for step content
  in ResearchView, enabling proper markdown rendering with streaming
- Update LLM prompts to request markdown-formatted responses
- Add file export with SaveFileDialog supporting Markdown (.md),
  HTML (.html), and XPS (.xps) formats via new ResearchExportService
- Add Markdig NuGet package for markdown-to-HTML conversion
- Store completed research sessions in SQLite (ResearchSessions table)
  with query, synthesized result, steps JSON, and metadata
- Add ResearchHistoryView with list-detail layout, search, date filters,
  markdown-rendered step detail panel, and export/copy/delete actions
- Add ResearchHistoryViewModel, IResearchHistoryService, and
  ResearchHistoryService following existing HistoryService patterns
- Wire Research History into sidebar navigation (Research mode only)
- Add localization strings (EN, DE, FR) for all new UI elements

https://claude.ai/code/session_01MY3a5PV1cPMNeAuNRkTuNg